### PR TITLE
Fix solver branch logic

### DIFF
--- a/Ideal_Gas_Laws_Calculator.py
+++ b/Ideal_Gas_Laws_Calculator.py
@@ -129,7 +129,7 @@ def calculator():
   def solver():
       if moles == 0:
           print("The answer is" ,(pressure * volume) / (R * temperature), "moles.")
-      if pressure == 0:
+      elif pressure == 0:
           print("The answer is", (moles * R * temperature) / volume, "atm")
       elif temperature == 0:
           print("The answer is", (pressure * volume) /(R * moles), "Kelvin")


### PR DESCRIPTION
## Summary
- ensure only one solver branch runs when determining the missing ideal gas variable

## Testing
- `echo 'If I have 0.5 moles of gas at a pressure of 150 atm and a temperature of 27 Celsius, what volume will it occupy?' | python3 Ideal_Gas_Laws_Calculator.py`
- `echo 'If I have 2 moles of gas at a volume of 10 Liters and a temperature of 27 Celsius, what is the pressure?' | python3 Ideal_Gas_Laws_Calculator.py`


------
https://chatgpt.com/codex/tasks/task_e_684976fdc2e88332b68deaad795f822c