### PR TITLE
Improve unit parsing for ideal gas calculator

### DIFF
--- a/Ideal_Gas_Laws_Calculator.py
+++ b/Ideal_Gas_Laws_Calculator.py
@@ -12,13 +12,15 @@ def calculator():
 
   The user is prompted to paste a single sentence problem that contains the
   numeric values and units for pressure, volume, temperature and amount of gas
-  (either in moles or grams). Units must be separated from numbers by a space.
+  (either in moles or grams). Units can be written next to numbers (e.g. ``23C``)
+  or separated from them by a space.
   After parsing the text and converting values to standard units, the function
   prints the computed value of the one variable that was omitted from the
   question.
   """
 
   import time
+  import re
   # Ideal gas constant
   R = 0.0821
   #Conversion factor to go from Celsius to Kelvin
@@ -64,7 +66,11 @@ def calculator():
 #instructions for the program
   print("Copy and paste the Ideal Gas Law problem here that you want answered.")
 #this asks the user to paste their question into the console.
-  text = input("(Make sure there is a space between any units and numerical values)" )
+  text = input("(Units can be written with or without a space, e.g. 23C or 23 C)" )
+
+  # allow units to be attached to numbers, e.g. "23C" or "150atm"
+  unit_pattern = r"(\d+(?:\.\d+)?)(°C|C|Celsius|K|Kelvin|L|Liters|mL|milliliters|atm|atmospheres|moles|mol|g|grams)"
+  text = re.sub(unit_pattern, r"\1 \2", text)
 
 #This block removes any extraneous punctuation that would stop the script from identifying variables
   emptyString = " "
@@ -97,7 +103,7 @@ def calculator():
   time.sleep(1.5)
 #This looks for the temperature value and converts accordingly to Kelvin
   for index, value in enumerate(m_data):
-      if value == "°C" or value == "Celsius":
+      if value == "°C" or value == "Celsius" or value == "C":
           temperature = float(m_data[index - 1]) + k
           print("temperature is equal to", temperature, "Kelvin")
           break

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This repository hosts the script that I wrote to solve word problems that are pasted into it. It is used specifically to solve ideal gas law problems that utilize the PV=nRT formula.
 
 This script will take a text that is copied and pasted into the console and parse it out to find the correct values to assign to the corresponding variables from the formula listed above.
+Units may be written immediately after numbers (e.g. `23C`) or separated by a space.
 
 It will then solve for the missing variable.
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -21,3 +21,20 @@ def test_calculator(monkeypatch, capsys):
     Ideal_Gas_Laws_Calculator.calculator()
     output = capsys.readouterr().out.strip().splitlines()
     assert output[-1] == "The answer is 0.0821 Liters"
+
+
+def test_calculator_concatenated_units(monkeypatch, capsys):
+    question = (
+        "What volume of CO2 is needed to fill an 0.5moles tank to a pressure of 150.0atm at 27C?"
+    )
+    monkeypatch.setattr(builtins, "input", lambda _: question)
+    monkeypatch.setattr("time.sleep", lambda _ : None)
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+    import Ideal_Gas_Laws_Calculator
+    importlib.reload(Ideal_Gas_Laws_Calculator)
+
+    Ideal_Gas_Laws_Calculator.calculator()
+    output = capsys.readouterr().out.strip().splitlines()
+    assert output[-1] == "The answer is 0.0821 Liters"


### PR DESCRIPTION
## Summary
- allow units to be written without spaces (e.g. `23C`)
- update documentation about flexible unit input
- add test for inputs with concatenated units

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497c33bb9483329f724e22bdbf4465