### PR TITLE
Move main call under guard

### DIFF
--- a/Ideal_Gas_Laws_Calculator.py
+++ b/Ideal_Gas_Laws_Calculator.py
@@ -166,4 +166,6 @@ def calculator():
       else:
             print("The answer is",(moles * R * temperature) / (pressure),"Liters")
   solver(pressure, volume, moles, temperature, R)
-calculator()
+
+if __name__ == "__main__":
+  calculator()


### PR DESCRIPTION
## Summary
- prevent `calculator()` from running on import by guarding call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a228a47048332b734805c97e75ef6