### PR TITLE
Implement kPa support and adjust Kelvin offset

### DIFF
--- a/Ideal_Gas_Laws_Calculator.py
+++ b/Ideal_Gas_Laws_Calculator.py
@@ -23,8 +23,8 @@ def calculator():
   import re
   # Ideal gas constant
   R = 0.0821
-  #Conversion factor to go from Celsius to Kelvin
-  k = 273
+#Conversion factor to go from Celsius to Kelvin
+  k = 273.15
 #kPa conversion factor
   kPa = 101.3
   print("Welcome to the ideal gas laws calculator!")
@@ -122,6 +122,10 @@ def calculator():
       val = value.lower()
       if val in ("atm", "atmospheres"):
           pressure = float(m_data[index - 1])
+          print("pressure is equal to", pressure, "atm")
+          break
+      if val in ("kpa", "kilopascals", "kilopascal"):
+          pressure = float(m_data[index - 1]) / kPa
           print("pressure is equal to", pressure, "atm")
           break
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -20,7 +20,7 @@ def test_calculator(monkeypatch, capsys):
 
     Ideal_Gas_Laws_Calculator.calculator()
     output = capsys.readouterr().out.strip().splitlines()
-    assert output[-1] == "The answer is 0.0821 Liters"
+    assert output[-1] == "The answer is 0.08214105 Liters"
 
 
 def test_calculator_concatenated_units(monkeypatch, capsys):
@@ -37,4 +37,21 @@ def test_calculator_concatenated_units(monkeypatch, capsys):
 
     Ideal_Gas_Laws_Calculator.calculator()
     output = capsys.readouterr().out.strip().splitlines()
-    assert output[-1] == "The answer is 0.0821 Liters"
+    assert output[-1] == "The answer is 0.08214105 Liters"
+
+
+def test_calculator_kpa(monkeypatch, capsys):
+    question = (
+        "What volume of CO2 is needed to fill an 0.5 moles tank to a pressure of 101.3 kPa at 27 Celsius?"
+    )
+    monkeypatch.setattr(builtins, "input", lambda _: question)
+    monkeypatch.setattr("time.sleep", lambda _ : None)
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+    import Ideal_Gas_Laws_Calculator
+    importlib.reload(Ideal_Gas_Laws_Calculator)
+
+    Ideal_Gas_Laws_Calculator.calculator()
+    output = capsys.readouterr().out.strip().splitlines()
+    assert output[-1] == "The answer is 12.3211575 Liters"


### PR DESCRIPTION
## Summary
- support pressure values specified in kPa
- update Celsius to Kelvin conversion constant
- update tests for new Kelvin offset and add kPa test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a239b7fa88332b36a75c01920fe77