### PR TITLE
Remove delays from CLI tests

### DIFF
--- a/Ideal_Gas_Laws_Calculator.py
+++ b/Ideal_Gas_Laws_Calculator.py
@@ -7,7 +7,7 @@
 # Example 4: What volume is occupied by 5.03 moles of O2 at 28 °C and a pressure of 0.998 atm?
 # Example 5: What volume is occupied by 5.03 grams of O2 at 28 °C and a pressure of 0.998 atm?
 
-def calculator():
+def calculator(pause=True):
   """Parse a pasted ideal gas law word problem and output the missing value.
 
   The user is prompted to paste a single sentence problem that contains the
@@ -17,6 +17,13 @@ def calculator():
   After parsing the text and converting values to standard units, the function
   prints the computed value of the one variable that was omitted from the
   question.
+
+  Parameters
+  ----------
+  pause : bool, optional
+      When ``True`` (default), pause for a short time between printing the
+      parsed values to make the output easier to read. Set to ``False`` to
+      disable the delays (useful for tests).
   """
 
   import time
@@ -103,7 +110,8 @@ def calculator():
           print("volume is equal to", volume, "Liters")
           break
 
-  time.sleep(1.5)
+  if pause:
+      time.sleep(1.5)
 #This looks for the temperature value and converts accordingly to Kelvin
   for index, value in enumerate(m_data):
       val = value.lower()
@@ -116,7 +124,8 @@ def calculator():
           print("temperature is equal to", temperature, "Kelvin")
           break
 
-  time.sleep(1.5)        
+  if pause:
+      time.sleep(1.5)
 #Identifies pressure value and converts to atm.
   for index, value in enumerate(m_data):
       val = value.lower()
@@ -129,7 +138,8 @@ def calculator():
           print("pressure is equal to", pressure, "atm")
           break
 
-  time.sleep(1.5)
+  if pause:
+      time.sleep(1.5)
 
 # identifies the moles value and assigns it to the corresponding variable
   gas_name = None
@@ -152,7 +162,8 @@ def calculator():
               moles = grams / gas_symbol_lower[gas_name]
               print("mass is equal to", moles, "moles")
           break
-  time.sleep(1.5)
+  if pause:
+      time.sleep(1.5)
 
   def solver(pressure, volume, moles, temperature, R):
       """Solve for whichever ideal gas variable is missing.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Run the calculator from the command line:
 python Ideal_Gas_Laws_Calculator.py
 ```
 
+The script pauses briefly between printing each detected value. When using the
+function programmatically, you can disable these delays by calling
+``calculator(pause=False)``.
+
 After launching, paste an ideal gas law word problem at the prompt. For example:
 
 ```text

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -11,14 +11,13 @@ def test_calculator(monkeypatch, capsys):
         "What volume of CO2 is needed to fill an 0.5 moles tank to a pressure of 150.0 atm at 27.0 Celsius?"
     )
     monkeypatch.setattr(builtins, "input", lambda _: question)
-    monkeypatch.setattr("time.sleep", lambda _ : None)
 
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
     import Ideal_Gas_Laws_Calculator
     importlib.reload(Ideal_Gas_Laws_Calculator)
 
-    Ideal_Gas_Laws_Calculator.calculator()
+    Ideal_Gas_Laws_Calculator.calculator(pause=False)
     output = capsys.readouterr().out.strip().splitlines()
     assert output[-1] == "The answer is 0.08214105 Liters"
 
@@ -28,14 +27,13 @@ def test_calculator_concatenated_units(monkeypatch, capsys):
         "What volume of CO2 is needed to fill an 0.5moles tank to a pressure of 150.0atm at 27C?"
     )
     monkeypatch.setattr(builtins, "input", lambda _: question)
-    monkeypatch.setattr("time.sleep", lambda _ : None)
 
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
     import Ideal_Gas_Laws_Calculator
     importlib.reload(Ideal_Gas_Laws_Calculator)
 
-    Ideal_Gas_Laws_Calculator.calculator()
+    Ideal_Gas_Laws_Calculator.calculator(pause=False)
     output = capsys.readouterr().out.strip().splitlines()
     assert output[-1] == "The answer is 0.08214105 Liters"
 
@@ -45,13 +43,12 @@ def test_calculator_kpa(monkeypatch, capsys):
         "What volume of CO2 is needed to fill an 0.5 moles tank to a pressure of 101.3 kPa at 27 Celsius?"
     )
     monkeypatch.setattr(builtins, "input", lambda _: question)
-    monkeypatch.setattr("time.sleep", lambda _ : None)
 
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
     import Ideal_Gas_Laws_Calculator
     importlib.reload(Ideal_Gas_Laws_Calculator)
 
-    Ideal_Gas_Laws_Calculator.calculator()
+    Ideal_Gas_Laws_Calculator.calculator(pause=False)
     output = capsys.readouterr().out.strip().splitlines()
     assert output[-1] == "The answer is 12.3211575 Liters"

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -13,14 +13,13 @@ def test_example2(monkeypatch, capsys):
         "If I have 4 moles of gas at a pressure of 5.6 atm and a volume of 12 Liters, what is the temperature?"
     )
     monkeypatch.setattr(builtins, "input", lambda _: question)
-    monkeypatch.setattr("time.sleep", lambda _ : None)
 
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
     import Ideal_Gas_Laws_Calculator
     importlib.reload(Ideal_Gas_Laws_Calculator)
 
-    Ideal_Gas_Laws_Calculator.calculator()
+    Ideal_Gas_Laws_Calculator.calculator(pause=False)
     output = capsys.readouterr().out.strip().splitlines()
     assert output[-1] == "The answer is 204.62850182704014 Kelvin"
 
@@ -32,13 +31,12 @@ def test_example3(monkeypatch, capsys):
         "At what temperature would 2.10 moles of N2 gas have a pressure of 1.25 atm and in a 25.0 L tank?"
     )
     monkeypatch.setattr(builtins, "input", lambda _: question)
-    monkeypatch.setattr("time.sleep", lambda _ : None)
 
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
     import Ideal_Gas_Laws_Calculator
     importlib.reload(Ideal_Gas_Laws_Calculator)
 
-    Ideal_Gas_Laws_Calculator.calculator()
+    Ideal_Gas_Laws_Calculator.calculator(pause=False)
     output = capsys.readouterr().out.strip().splitlines()
     assert output[-1] == "The answer is 181.25398758772693 Kelvin"


### PR DESCRIPTION
## Summary
- make `calculator` pause optional via `pause` parameter
- document the `pause` option
- update tests to disable pauses without monkeypatching `time.sleep`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68502642d12c8332b479bca075c2ea29